### PR TITLE
Update Chown.class.php

### DIFF
--- a/amp_conf/htdocs/admin/libraries/Console/Chown.class.php
+++ b/amp_conf/htdocs/admin/libraries/Console/Chown.class.php
@@ -511,6 +511,9 @@ class Chown extends Command {
 	 */
 	public function chmod($progress, $files, $mode, $umask = 0000, $recursive = false, $stripx = true) {
 		foreach ($this->toIterator($files) as $file) {
+			if (!file_exists($file)) {
+				continue;
+			}
 			if(!is_null($progress)) {
 				$progress->advance();
 			}

--- a/amp_conf/htdocs/admin/libraries/Console/Chown.class.php
+++ b/amp_conf/htdocs/admin/libraries/Console/Chown.class.php
@@ -315,6 +315,9 @@ class Chown extends Command {
 		if(empty($path)) {
 			throw new \Exception("Path is empty!");
 		}
+		if (!file_exists($path)) {
+			return;
+		}
 		$blacklist = $this->blacklist;
 		if(!empty($blacklist['files'])) {
 			array_walk($blacklist['files'], function(&$value, $key) {
@@ -430,6 +433,9 @@ class Chown extends Command {
 	 */
 	public function chgrp($progress, $files, $group, $recursive = false) {
 		foreach ($this->toIterator($files) as $file) {
+			if (!file_exists($file)) {
+				continue;
+			}
 			if(!is_null($progress)) {
 				$progress->advance();
 			}
@@ -465,6 +471,9 @@ class Chown extends Command {
 	 */
 	public function chown($progress, $files, $user, $recursive = false) {
 		foreach ($this->toIterator($files) as $file) {
+			if (!file_exists($file)) {
+				continue;
+			}
 			if(!is_null($progress)) {
 				$progress->advance();
 			}


### PR DESCRIPTION
Don't try to process missing files and paths. Prevents notices for optional files (e.g. `/var/log/asterisk/freepbx_dbug`, `/etc/obdc.ini`, or `/etc/asterisk/keys/_account`) as well as any passed in through CLI or `/etc/asterisk/freepbx_chown.conf`.

Same patch could also be applied to 16.